### PR TITLE
fix: space between libParquet and function name

### DIFF
--- a/build.ijs
+++ b/build.ijs
@@ -5,4 +5,5 @@ NB. Reads content of all files in .jproj as a string.
 NB. readsource_jp_ 'PacmanDev/Arrow'
 
 NB. Writes content of all files in .jproj into a single file. 
-writesourcex_jp_ 'JPackageDev/Arrow';'~addons/data/arrow/arrow.ijs' NB. Reads all files in .jproj
+writesourcex_jp_ 'JPackageDev/arrow';'~addons/data/arrow/arrow.ijs' NB. Reads all files in .jproj
+

--- a/init.ijs
+++ b/init.ijs
@@ -21,7 +21,7 @@ end.
 
 cbind =: 3 : 0"1
 'type name args' =. y
-v =. (libParquet,name,' ',type)&cd
+v =. (libParquet,' ',name,' ',type)&cd
 (". 'name') =: v
 1
 )

--- a/run.ijs
+++ b/run.ijs
@@ -30,6 +30,7 @@ pd.DataFrame(
 'DoubleCol':np.array(np.arange(100, 10, -90/8), dtype=np.double),
 'StringCol':pd.array(['This', ' is', 'all', ' valid ', 'text', None, 'data.', ''], dtype="string"),
 'boolCol':np.array([1, 0.5, 0, None, 'a', '', True, False], dtype=bool),
+'datetime64Col':np.array(np.arange('2000-01', '2000-01-09', dtype='datetime64[D]')),
 }).to_parquet('WD/test2.parquet')
 )
 


### PR DESCRIPTION
Minor fix, there was no space between the dll path (...libparquet-glib.so on linux) and the function name.