### PR TITLE
Improve installation on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ see `test/test1.ijs`
 ##### TODO
 * [x] Figure out how to formalize data/arrow.ijs as an add-on
 * [x] `install 'github:interregna/JArrow@main'`
-* [ ] Drop functions into a jarrow locale and link entry points up to z locale.
+* [x] Drop functions into a `parrow` locale and link entry points up to z locale.
 * [ ] Document functions: Print a manual / help dialog.
 * [ ] J for buffers
 * [ ] J for errors

--- a/arrow.ijs
+++ b/arrow.ijs
@@ -1,4 +1,5 @@
 NB. init
+cocurrent 'parrow'
 
 lib =: >@((3&{.)@(TAB&cut)&.>)@(LF&cut)
 ret =: 0&{::
@@ -1447,3 +1448,9 @@ writeParquet=: {{
 writeParquetFromTable=: {{
   'table writeOptions' =. y
 }}
+NB. ====================
+NB. Expose public interface in z locale
+
+readParquetTable_z_=: readParquetTable_parrow_
+readsParquetTable_z_=: readsParquetTable_parrow_
+readParquetSchema_z_=: readParquetSchema_parrow_

--- a/arrow.ijs
+++ b/arrow.ijs
@@ -9,8 +9,8 @@ setChar =: {{p [ y memw p,0,(# y),2 [ p=.mema # y=.(>y),{.a.}}
 
 libload =: {{
   if.     UNAME-:'Linux' do.
-    libParquet =: '/lib/x86_64-linux-gnu/libparquet-glib.so'
-    libArrow   =: '/lib/x86_64-linux-gnu/libarrow-glib.so'
+    libParquet =: '/usr/lib/x86_64-linux-gnu/libparquet-glib.so'
+    libArrow   =: '/usr/lib/x86_64-linux-gnu/libarrow-glib.so'
   elseif. UNAME-:'Darwin' do.
     libParquet =: '"','" ',~  '/usr/local/lib/libparquet-glib.dylib'
     libArrow   =: '"','" ',~  '/usr/local/lib/libarrow-glib.dylib'

--- a/arrow.jproj
+++ b/arrow.jproj
@@ -20,3 +20,4 @@ src/data/value.ijs
 src/io/io.ijs
 src/ipc/ipc.ijs
 src/arrow.ijs
+src/public.ijs

--- a/manifest.ijs
+++ b/manifest.ijs
@@ -4,6 +4,12 @@ DESCRIPTION=: 0 : 0
 Apache Arrow API
 
 See details at: https://arrow.apache.org
+
+Version number should match Apache Arrow GLib and Apache Parquet GLib.
+
+See documentation at:
+https://arrow.apache.org/docs/c_glib/arrow-glib/
+https://arrow.apache.org/docs/c_glib/parquet-glib/
 )
 
 VERSION=: '7.0.0'
@@ -22,11 +28,6 @@ test/test2.parquet
 )
 
 DEPENDS=: 0 : 0
-Version number should match Apache Arrow GLib and Apache Parquet GLib.
-
-See documentation at:
-https://arrow.apache.org/docs/c_glib/arrow-glib/
-https://arrow.apache.org/docs/c_glib/parquet-glib/
 )
 
-PLATFORMS=:'Linux Darwin Windows'
+PLATFORMS=:'Darwin Windows Linux'

--- a/manifest.ijs
+++ b/manifest.ijs
@@ -30,3 +30,4 @@ test/test2.parquet
 DEPENDS=: 0 : 0
 )
 
+PLATFORMS=:''

--- a/manifest.ijs
+++ b/manifest.ijs
@@ -30,4 +30,4 @@ test/test2.parquet
 DEPENDS=: 0 : 0
 )
 
-PLATFORMS=:'Darwin Windows Linux'
+PLATFORMS=:''

--- a/manifest.ijs
+++ b/manifest.ijs
@@ -30,4 +30,3 @@ test/test2.parquet
 DEPENDS=: 0 : 0
 )
 
-PLATFORMS=:''

--- a/src/init.ijs
+++ b/src/init.ijs
@@ -1,4 +1,5 @@
 NB. init
+cocurrent 'parrow'
 
 lib =: >@((3&{.)@(TAB&cut)&.>)@(LF&cut)
 ret =: 0&{::

--- a/src/init.ijs
+++ b/src/init.ijs
@@ -9,8 +9,8 @@ setChar =: {{p [ y memw p,0,(# y),2 [ p=.mema # y=.(>y),{.a.}}
 
 libload =: {{
   if.     UNAME-:'Linux' do.
-    libParquet =: '/lib/x86_64-linux-gnu/libparquet-glib.so'
-    libArrow   =: '/lib/x86_64-linux-gnu/libarrow-glib.so'
+    libParquet =: '/usr/lib/x86_64-linux-gnu/libparquet-glib.so'
+    libArrow   =: '/usr/lib/x86_64-linux-gnu/libarrow-glib.so'
   elseif. UNAME-:'Darwin' do.
     libParquet =: '"','" ',~  '/usr/local/lib/libparquet-glib.dylib'
     libArrow   =: '"','" ',~  '/usr/local/lib/libarrow-glib.dylib'

--- a/src/public.ijs
+++ b/src/public.ijs
@@ -1,0 +1,6 @@
+NB. ====================
+NB. Expose public interface in z locale
+
+readParquetTable_z_=: readParquetTable_parrow_
+readsParquetTable_z_=: readsParquetTable_parrow_
+readParquetSchema_z_=: readParquetSchema_parrow_

--- a/test/test1.ijs
+++ b/test/test1.ijs
@@ -11,6 +11,8 @@ NB. copy test parquet files to ~temp if they're not already there
 }}''
 
 load ProjPath,'/arrow.ijs'
+coinsert 'parrow'
+
 t1path =. TempPath,'test1.parquet'
 tp1 =. readParquet t1path
 echo readSchemaString tp1


### PR DESCRIPTION
Installing the addin from Github was not working on Linux. Executing `install 'github:interregna/JArrow@main'` resulted in an error reporting that the addon didn't support the current platform. Assigning an empty string to `PLATFORM` in the manifest fixed this. Not sure if this is a bug in the J package manager.

The `DEPENDS` option in the manifest is intended for specifying other addons dependencies that should automatically be installed as well.

On an Ubuntu 20.04 installation the parquet libraries are available in `/lib/x86_64-linux-gnu` and `/usr/lib/x86_64-linux-gnu`, but on 18.04 they only seem to be in `/usr/lib/x86_64-linux-gnu` which seems like the logical place for them anyway?
