### PR TITLE
Add option to read parquet as jdataframe

### DIFF
--- a/arrow.ijs
+++ b/arrow.ijs
@@ -1377,8 +1377,15 @@ tableNCols=:{{ret garrow_table_get_n_columns (< y)}}
 readData=:{{
   'tablePt' =. y
   ncols =. tableNCols tablePt
-  chunkedArrayPts =. <"0 ptr"1 garrow_table_get_column_data (< tablePt),. <"0 i. ncols
+  chunkedArrayPts =. <"0 ptr"1 garrow_table_get_column_data tablePt ;"0 i. ncols
   ,. > readChunkedArray each chunkedArrayPts
+}}
+
+readDataInverted=:{{
+  'tablePt' =. y
+  ncols =. tableNCols tablePt
+  chunkedArrayPts =. {."1 garrow_table_get_column_data tablePt ;"0 i. ncols
+  , readChunkedArray"0 chunkedArrayPts
 }}
 
 readDataColumn=:{{
@@ -1404,6 +1411,11 @@ readsTable=:{{
   ((,@readSchemaNames),:(,@:(,.&.>)@:readData)) tablePt
 }}
 
+readDataframe=:{{
+  'tablePt' =. y
+  (readSchemaNames,:readDataInverted) tablePt
+}}
+
 NB. =========================================================
 NB. Parquet
 NB. =========================================================
@@ -1426,6 +1438,11 @@ readParquetData=:{{
   readData@readParquet filepath
 }}
 
+readParquetDataInverted=:{{
+  'filepath'=.y
+  readDataInverted@readParquet filepath
+}}
+
 readParquetTable=:{{
   'filepath'=.y
   readTable@readParquet filepath
@@ -1434,6 +1451,11 @@ readParquetTable=:{{
 readsParquetTable=:{{
   'filepath'=.y
   readsTable@readParquet filepath
+}}
+
+readParquetDataframe=:{{
+  'filepath'=.y
+  readDataframe@readParquet filepath
 }}
 
 readParquetColumn =: {{

--- a/src/arrow.ijs
+++ b/src/arrow.ijs
@@ -173,8 +173,15 @@ tableNCols=:{{ret garrow_table_get_n_columns (< y)}}
 readData=:{{
   'tablePt' =. y
   ncols =. tableNCols tablePt
-  chunkedArrayPts =. <"0 ptr"1 garrow_table_get_column_data (< tablePt),. <"0 i. ncols
+  chunkedArrayPts =. <"0 ptr"1 garrow_table_get_column_data tablePt ;"0 i. ncols
   ,. > readChunkedArray each chunkedArrayPts
+}}
+
+readDataInverted=:{{
+  'tablePt' =. y
+  ncols =. tableNCols tablePt
+  chunkedArrayPts =. {."1 garrow_table_get_column_data tablePt ;"0 i. ncols
+  , readChunkedArray"0 chunkedArrayPts
 }}
 
 readDataColumn=:{{
@@ -200,6 +207,11 @@ readsTable=:{{
   ((,@readSchemaNames),:(,@:(,.&.>)@:readData)) tablePt
 }}
 
+readDataframe=:{{
+  'tablePt' =. y
+  (readSchemaNames,:readDataInverted) tablePt
+}}
+
 NB. =========================================================
 NB. Parquet
 NB. =========================================================
@@ -222,6 +234,11 @@ readParquetData=:{{
   readData@readParquet filepath
 }}
 
+readParquetDataInverted=:{{
+  'filepath'=.y
+  readDataInverted@readParquet filepath
+}}
+
 readParquetTable=:{{
   'filepath'=.y
   readTable@readParquet filepath
@@ -230,6 +247,11 @@ readParquetTable=:{{
 readsParquetTable=:{{
   'filepath'=.y
   readsTable@readParquet filepath
+}}
+
+readParquetDataframe=:{{
+  'filepath'=.y
+  readDataframe@readParquet filepath
 }}
 
 readParquetColumn =: {{

--- a/test/test1.ijs
+++ b/test/test1.ijs
@@ -18,13 +18,16 @@ tp1 =. readParquet t1path
 echo readSchemaString tp1
 echo readSchema tp1
 echo readData tp1
+echo readDataInverted tp2
 echo readTable tp1
 echo readsTable tp1
+echo readDataframe tp1
 
 echo readParquetData t1path
 echo readParquetSchema t1path
 echo readParquetTable t1path
 echo readsParquetTable t1path
+echo readParquetDataframe t1path
 echo readParquetColumn t1path;1
 
 NB. =========================================================
@@ -33,11 +36,14 @@ tp2 =. readParquet t2path
 echo readSchemaString tp2
 echo readSchema tp2
 echo readData tp2
+echo readDataInverted tp2
 echo readTable tp2
 echo readsTable tp2
+echo readDataframe tp2
 
 echo readParquetSchema t2path
 echo readParquetData t2path
 echo readParquetTable t2path
 echo readsParquetTable t2path
+echo readParquetDataframe t2path
 echo readParquetColumn t2path;14


### PR DESCRIPTION
Neither of the current options (`readParquetTable` and `readsParquetTable`) builds a result in the same format as expected by the current implementation of a [Jdataframe](https://github.com/tikkanz/jdataframe), i.e. an inverted table with a header row.

Until we get a consensus of what the "right" format is for a dataframe in J, this additional option will enable the two addins to interoperate. 