### PR TITLE
readParquetSchema without loading entire file

### DIFF
--- a/arrow.ijs
+++ b/arrow.ijs
@@ -1898,7 +1898,21 @@ memf > e
 tablePtr
 }}
 
-readParquetSchema=: (readParquet readFileSchema)
+NB. readParquetSchema=: (readParquet readFileSchema)
+readParquetSchema=: {{
+NB. use gparquet_arrow_file_reader_get_schema instead of reading entire file into memory first
+'filepath'=. y
+'File does not exist or is not permissioned for read.' assert fexist (jpath filepath)
+e=. < mema 4
+readerPathPtr=. ptr gparquet_arrow_file_reader_new_path (jpath filepath);<e
+schemaPt=. ptr gparquet_arrow_file_reader_get_schema readerPathPtr;<e
+removeObject readerPathPtr
+memf > e
+res=. getSchemaFields schemaPt
+removeObject schemaPt
+res
+}}
+
 printParquetSchema=: (readParquet printFileSchema)
 readParquetData=: (readParquet readFileData)
 readParquetTable=: (readParquet readFileTable)


### PR DESCRIPTION
Intended to allow reading just the schema from a parquet file without having to read all of the data into memory.

Unfortunately this approach still reads the entire file into memory (and then seems to leak that memory immediately...).

It looks like this is a limitation of the arrow glib C binding but that seems so brain-dead that I surely must be wrong...